### PR TITLE
feat: responsive layout and mobile navigation

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -5,12 +5,16 @@
   --color-white: #FFFFFF;
 }
 * {box-sizing: border-box; margin: 0; padding: 0;}
+img {max-width: 100%; height: auto;}
 body {font-family: 'Roboto', sans-serif; background-color: var(--color-white); color: var(--color-graphite); line-height: 1.6;}
-header {display: flex; align-items: center; justify-content: space-between; padding: 1rem 2rem; background-color: var(--color-white); box-shadow: 0 2px 4px rgba(0,0,0,.1);}
+header {display: flex; align-items: center; justify-content: space-between; padding: 1rem 2rem; background-color: var(--color-white); box-shadow: 0 2px 4px rgba(0,0,0,.1); position: relative;}
 header .logo {display: flex; align-items: center;}
 header .logo img {height: 40px;}
-nav a {margin-left: 1rem; text-decoration: none; color: var(--color-graphite); font-weight: 500;}
+nav {display: none; flex-direction: column; position: absolute; top: 100%; left: 0; right: 0; background-color: var(--color-white); padding: 1rem 2rem; box-shadow: 0 2px 4px rgba(0,0,0,.1);}
+nav a {margin: 0.5rem 0; text-decoration: none; color: var(--color-graphite); font-weight: 500;}
 nav a:hover {color: var(--color-green);}
+nav.active {display: flex;}
+.menu-toggle {background: none; border: none; font-size: 1.5rem; cursor: pointer;}
 section {padding: 4rem 2rem; max-width: 1000px; margin: 0 auto;}
 .hero {background: linear-gradient(135deg, var(--color-green), var(--color-gold)); color: var(--color-white); padding: 6rem 2rem; text-align: center;}
 .hero h1 {font-family: 'Montserrat', sans-serif; font-size: 2.5rem; margin-bottom: 1rem;}
@@ -24,7 +28,23 @@ footer {text-align: center; padding: 1.5rem; background-color: #f5f5f5; color: v
 footer a {color: var(--color-green); text-decoration: none;}
 footer a:hover {text-decoration: underline;}
 @media (max-width: 600px) {
-  nav a {margin-left: 0.5rem;}
   .hero h1 {font-size: 2rem;}
   .hero p {font-size: 1rem;}
+}
+@media (min-width: 768px) {
+  .menu-toggle {display: none;}
+  nav {display: flex; flex-direction: row; position: static; padding: 0; box-shadow: none;}
+  nav a {margin: 0 0 0 1rem;}
+  section {padding: 5rem 3rem;}
+  .hero {padding: 6rem 3rem;}
+  .hero h1 {font-size: 3rem;}
+  .hero p {font-size: 1.25rem;}
+}
+@media (min-width: 1024px) {
+  header {padding: 1rem 4rem;}
+  nav a {margin-left: 2rem;}
+  section {padding: 6rem 4rem; max-width: 1200px;}
+  .hero {padding: 8rem 4rem;}
+  .hero h1 {font-size: 3.5rem;}
+  .hero p {font-size: 1.5rem;}
 }

--- a/index.html
+++ b/index.html
@@ -18,6 +18,7 @@
   <div class="logo">
     <img src="assets/logo-bettermin-definitivo.svg" alt="BetterMin">
   </div>
+  <button class="menu-toggle" aria-label="Menú" type="button">☰</button>
   <nav>
     <a href="#quienes">Quiénes somos</a>
     <a href="#ecopilot">Eco‑Pilot</a>
@@ -73,6 +74,9 @@
 </footer>
 <script>
 document.getElementById('year').textContent = new Date().getFullYear();
+const menuToggle = document.querySelector('.menu-toggle');
+const nav = document.querySelector('nav');
+menuToggle.addEventListener('click', () => nav.classList.toggle('active'));
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add hamburger menu for small screens and toggle script
- introduce responsive breakpoints at 768px and 1024px with spacing and typography adjustments
- ensure images and sections scale fluidly across screen sizes

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c75959b7b0832f90cf710126db5acd