### PR TITLE
Use HashRouter for routing

### DIFF
--- a/src/main.jsx
+++ b/src/main.jsx
@@ -2,12 +2,12 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App.jsx';
 import './index.css';
-import { BrowserRouter } from 'react-router-dom';
+import { HashRouter } from 'react-router-dom';
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
-    <BrowserRouter>
+    <HashRouter>
       <App />
-    </BrowserRouter>
+    </HashRouter>
   </React.StrictMode>,
 );


### PR DESCRIPTION
## Summary
- replace `BrowserRouter` with `HashRouter` in the app entry point to support static hosting

## Testing
- `npm test`
- `npm run build` *(fails: vite not found; npm install 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c76b37da78832fb055bb39cf1254cc